### PR TITLE
Now static

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,46 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/static-build"
+    }
+  ],
+  "routes": [
+    {
+      "src": "^/assets/(.*)",
+      "dest": "/assets/$1"
+    },
+    {
+      "src": "^/favicon.ico",
+      "dest": "/favicon.ico"
+    },
+    {
+      "src": "^/manifest.webmanifest",
+      "dest": "/manifest.webmanifest"
+    },
+    {
+      "src": "^/sw.js",
+      "headers": {
+        "cache-control": "s-maxage=0"
+      },
+      "dest": "/sw.js"
+    },
+    {
+      "src": "^/style.css",
+      "dest": "/style.css"
+    },
+    {
+      "src": "^/style.css.map",
+      "dest": "/style.css.map"
+    },
+    {
+      "src": "^/bundle.js",
+      "dest": "/bundle.js"
+    },
+    {
+      "src": "^/(.*)",
+      "dest": "/index.html"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "schichtkalender-bosch-rt",
   "version": "3.0.0",
   "description": "Listet alle Kontischichten vom Bosch Reutlingen auf.",
+  "private": true,
   "scripts": {
     "dev": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --progress",
     "start": "serve build -s -c 1",
     "prestart": "npm run build",
     "build": "cross-env NODE_ENV=production webpack --progress",
     "prebuild": "mkdirp build && ncp src/assets build/assets",
+    "now-build": "npm run build && mv build dist",
     "test": "npm run -s lint && jest --coverage",
     "test:watch": "npm run -s test -- --watch",
     "lint": "eslint src test"


### PR DESCRIPTION
Add [now](zeit.co) deployment.

This pull request changes:
- Add [now.json](https://zeit.co/docs/v2/deployments/configuration/) for the zeit config
- Add a now-build script