### PR TITLE
Fixes for time calcs

### DIFF
--- a/components/header-nav-links.jsx
+++ b/components/header-nav-links.jsx
@@ -29,6 +29,7 @@ export default function HeaderNavLinks ({ year, month, isFullYear, shiftModel, g
     const then = new Date()
     then.setFullYear(year)
     then.setMonth(month - 1)
+    then.setDate(3)
 
     return {
       lastMonth: getMonthUrl(then.getTime() - ms.months(1), isFullYear, shiftModel, group),

--- a/lib/workdata.js
+++ b/lib/workdata.js
@@ -5,6 +5,8 @@ This Source Code Form is subject to the terms of the Mozilla Public License, v. 
 the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+import ms from 'milliseconds'
+
 import {
   shift66Name,
   shift64Name,
@@ -21,15 +23,11 @@ import { getDaysInMonth } from './utils.js'
  * @param {number} day   Day in month
  */
 function getTime (year, month, day) {
-  const date = new Date(year, month, day, 0, 0, 0, 0)
-  date.setUTCFullYear(year)
-  date.setUTCMonth(month)
-  date.setUTCDate(day)
-  date.setUTCHours(0)
-  date.setUTCMinutes(0)
-  date.setUTCSeconds(0)
-  date.setUTCMilliseconds(0)
-  const time = date.getTime()
+  const monthStr = String(month + 1).padStart(2, '0')
+  const dayStr = String(day).padStart(2, '0')
+  // use JSON string, because if UTC is used on some days it calculates the wrong shift.
+  const date = new Date(`${year}-${monthStr}-${dayStr}T03:00:00.000Z`)
+  const time = date.getTime() - ms.days(1)
   return time
 }
 
@@ -80,8 +78,8 @@ function get66Model (year, month) {
 
   for (let i = 0, days = getDaysInMonth(year, month); i < days; ++i) {
     const aDay = isOldModel || (isOnSwitch && i < 3) // if it is before the 2010-04-03
-      ? get44ModelDay(year, month, i) // get the old model
-      : get12DayCycleModelDay(year, month, i, [3, 0, 2, 5, 1, 4]) // else get the 6-6 model
+      ? get44ModelDay(year, month, i + 1) // get the old model
+      : get12DayCycleModelDay(year, month, i + 1, [3, 0, 2, 5, 1, 4]) // else get the 6-6 model
 
     daysData.push(aDay)
 
@@ -109,7 +107,7 @@ function get64Model (year, month) {
   const groupsWorkingDays = [0, 0, 0, 0, 0]
 
   for (let i = 0, days = getDaysInMonth(year, month); i < days; ++i) {
-    const aDay = get64ModelDay(year, month, i)
+    const aDay = get64ModelDay(year, month, i + 1)
 
     daysData.push(aDay)
 
@@ -137,7 +135,7 @@ function getWfWModel (year, month) {
   const groupsWorkingDays = [0, 0, 0, 0, 0, 0]
 
   for (let i = 0, days = getDaysInMonth(year, month); i < days; ++i) {
-    const aDay = get12DayCycleModelDay(year, month, i, [3, 2, 1, 0, 5, 4])
+    const aDay = get12DayCycleModelDay(year, month, i + 1, [3, 2, 1, 0, 5, 4])
 
     daysData.push(aDay)
 
@@ -286,7 +284,7 @@ function getAddedNightModel (year, month) {
   const groupsWorkingDays = [0, 0, 0]
 
   for (let i = 0, days = getDaysInMonth(year, month); i < days; ++i) {
-    const aDay = getAddedNightModelDay(year, month, i)
+    const aDay = getAddedNightModelDay(year, month, i + 1)
 
     daysData.push(aDay)
 
@@ -383,7 +381,7 @@ function getAddedNight8Model (year, month) {
  * @returns {("F"|"S"|"N"|"K")[]} Working data of all groups on this day
  */
 function getAddedNight8ModelDay (year, month, day) {
-  const time = getTime(year, month, day)
+  const time = getTime(year, month, day) + ms.days(1)
   const weekDay = new Date(time).getDay()
 
   // get days count since 1.1.1970


### PR DESCRIPTION
This pull request fixes:
- Some shifts not calculated correctly
- Next month link overflows to month after next month on the end of the month, if the current month is longer then the next month.