### PR TITLE
Fix not updating after tab restore

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -40,7 +40,7 @@ export default function MyApp ({ Component, pageProps }) {
         <meta name='apple-mobile-web-app-title' content='Schichtkalender' />
         <meta
           name='application-name'
-          content='Inoffizieller Schichtkalender für Bosch Reutlingen'
+          content='Schichtkalender Bosch RtP1'
         />
         <meta name='format-detection' content='telephone=no' />
         <meta name='theme-color' content='#064E3B' />

--- a/pages/cal/[shiftModel].jsx
+++ b/pages/cal/[shiftModel].jsx
@@ -5,6 +5,7 @@ This Source Code Form is subject to the terms of the Mozilla Public License, v. 
 the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+import { useEffect } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { DateTime, Info } from 'luxon'
@@ -12,7 +13,7 @@ import { DateTime, Info } from 'luxon'
 import ByMonths from '../../components/by-month'
 import Downloader from '../../components/download'
 import Legend from '../../components/legend'
-import { useTodayZeroIndex } from '../../hooks/time'
+import { useTodayZeroIndex, useUnloadedFix } from '../../hooks/time'
 import { shiftModelText } from '../../lib/constants'
 import { parseNumber } from '../../lib/utils'
 
@@ -28,6 +29,11 @@ export default function ShiftModel () {
   const group = parseNumber(router.query.group, 0)
   const year = today[0]
   const month = today[1]
+
+  const shouldRemoveCalendar = useUnloadedFix()
+  if (shouldRemoveCalendar) {
+    return null
+  }
 
   return (
     <main className={style.main}>

--- a/pages/cal/[shiftModel].jsx
+++ b/pages/cal/[shiftModel].jsx
@@ -5,7 +5,6 @@ This Source Code Form is subject to the terms of the Mozilla Public License, v. 
 the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-import { useEffect } from 'react'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { DateTime, Info } from 'luxon'

--- a/pages/cal/[shiftModel]/[year].jsx
+++ b/pages/cal/[shiftModel]/[year].jsx
@@ -12,7 +12,7 @@ import { DateTime, Info } from 'luxon'
 import Month from '../../../components/month'
 import Downloader from '../../../components/download'
 import Legend from '../../../components/legend'
-import { useTodayZeroIndex } from '../../../hooks/time'
+import { useTodayZeroIndex, useUnloadedFix } from '../../../hooks/time'
 import { shiftModelText } from '../../../lib/constants'
 import selectMonthData from '../../../lib/select-month-data'
 import { parseNumber } from '../../../lib/utils'
@@ -25,6 +25,11 @@ export default function Year () {
   const shiftModel = router.query.shiftModel
   const year = parseNumber(router.query.year, null)
   const group = parseNumber(router.query.group, 0)
+
+  const shouldRemoveCalendar = useUnloadedFix()
+  if (shouldRemoveCalendar) {
+    return null
+  }
 
   if (year == null) {
     return <h2>{router.query.year} is not a valid year.</h2>

--- a/pages/cal/[shiftModel]/[year]/[month].jsx
+++ b/pages/cal/[shiftModel]/[year]/[month].jsx
@@ -12,7 +12,7 @@ import { DateTime, Info } from 'luxon'
 import ByMonths from '../../../../components/by-month'
 import Downloader from '../../../../components/download'
 import Legend from '../../../../components/legend'
-import { useTodayZeroIndex } from '../../../../hooks/time'
+import { useTodayZeroIndex, useUnloadedFix } from '../../../../hooks/time'
 import { shiftModelText } from '../../../../lib/constants'
 import { parseNumber } from '../../../../lib/utils'
 
@@ -27,6 +27,11 @@ export default function MonthPage () {
   const month = monthQuery ? monthQuery - 1 : monthQuery
   const group = parseNumber(router.query.group, 0)
   const search = parseNumber(router.query.search, null)
+
+  const shouldRemoveCalendar = useUnloadedFix()
+  if (shouldRemoveCalendar) {
+    return null
+  }
 
   if (year == null) {
     return <h2>{router.query.year} is not a valid year.</h2>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,5 +1,5 @@
 {
-  "name": "Inoffizieller Schichtkalender für Bosch Reutlingen",
+  "name": "Schichtkalender Bosch RtP1",
   "short_name": "Kontischicht",
   "description": "Inoffizieller Schichtkalender für Bosch Reutlingen. Listet alle Kontischichten von Bosch Reutlingen auf.",
   "start_url": "./?pwa",


### PR DESCRIPTION
After a tab restore (because it was unloaded or browser closed) the today rows did not update.
If the month did change [shiftModel].jsx would mix two months in one table.