### PR TITLE
Add Content-Disposition header to excel_export

### DIFF
--- a/app/api/excel_export/all/[year]/[month]/route.ts
+++ b/app/api/excel_export/all/[year]/[month]/route.ts
@@ -11,6 +11,7 @@ import xl from "excel4node";
 import {
   shiftModelNames,
   shiftModelText,
+  excelExportName,
 } from "../../../../../../lib/constants";
 import {
   createShiftSheet,
@@ -56,5 +57,12 @@ export async function GET(
   }
 
   const buffer = await wb.writeToBuffer();
-  return new NextResponse(buffer);
+  return new NextResponse(buffer, {
+    headers: {
+      "Content-Disposition": `attachment; filename="${excelExportName(
+        year,
+        month,
+      )}"`,
+    },
+  });
 }

--- a/app/api/excel_export/shift/[model]/[year]/route.ts
+++ b/app/api/excel_export/shift/[model]/[year]/route.ts
@@ -12,6 +12,7 @@ import {
   monthNames,
   shiftModelNames,
   ShiftModels,
+  excelExportModelFullYearName,
 } from "../../../../../../lib/constants";
 import {
   createShiftSheet,
@@ -63,5 +64,12 @@ export async function GET(
   }
 
   const buffer = await wb.writeToBuffer();
-  return new NextResponse(buffer);
+  return new NextResponse(buffer, {
+    headers: {
+      "Content-Disposition": `attachment; filename="${excelExportModelFullYearName(
+        model,
+        year,
+      )}"`,
+    },
+  });
 }


### PR DESCRIPTION
Add [Content-Disposition header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) to excel_export.

This allows downloading it without clicking the link in `/download`.