### PR TITLE
Redesign header to use 2 rows

### DIFF
--- a/components/month.jsx
+++ b/components/month.jsx
@@ -74,22 +74,26 @@ function Month({
       </caption>
       <thead>
         <tr>
-          <th>
+          <th rowSpan={2}>
             <span className="sr-only">Woche</span>
             <span aria-hidden="true" title="Woche">
               Wo
             </span>
           </th>
-          <th>Tag</th>
-          <th>
+          <th rowSpan={2} className={style.clickable_column}>
+            Tag
+          </th>
+          <th rowSpan={2} className={style.clickable_column}>
             <span className="sr-only">Wochentag</span>
           </th>
+          <th colSpan={groups.length} className={style.groups_th}>
+            Gruppen
+          </th>
+        </tr>
+        <tr>
           {groups.map((gr) => (
-            <th key={gr}>
-              <span className="sr-only">{"Gruppe " + (gr + 1)}</span>
-              <span aria-hidden="true" title={"Gruppe " + (gr + 1)}>
-                Gr. {gr + 1}
-              </span>
+            <th key={gr} className={style.group_column}>
+              {gr + 1}
             </th>
           ))}
         </tr>

--- a/styles/calendar.module.css
+++ b/styles/calendar.module.css
@@ -54,6 +54,18 @@ But then show the next month on small screen, then the next 2 months, then all o
   border: 1px solid black;
   border: 1px solid var(--table-color);
 }
+
+.table caption,
+.table th,
+.table td {
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
+.table caption {
+  border-bottom: 1px solid white;
+  border-bottom: 1px solid var(--main-bg-color);
+}
+
 .table {
   margin-top: 2rem;
   text-align: center;
@@ -65,6 +77,18 @@ But then show the next month on small screen, then the next 2 months, then all o
   border-spacing: 0px;
   --interest-width: 3px;
   view-transition-name: month-table; /* animation is in index.css */
+}
+
+.table .groups_th {
+  border-bottom-width: 0px;
+}
+
+.clickable_column {
+  min-width: 50px;
+}
+
+.group_column {
+  min-width: 2rem;
 }
 
 .table th {
@@ -81,8 +105,8 @@ But then show the next month on small screen, then the next 2 months, then all o
 
 .table thead {
   position: sticky;
-  top: 4.5rem;
-  top: calc(3rem + 1.5rem - 1px);
+  top: 5rem;
+  top: calc(3.5rem + 1.5rem - 1px);
   z-index: 1;
 }
 
@@ -254,8 +278,8 @@ But then show the next month on small screen, then the next 2 months, then all o
 }
 .week_number {
   position: sticky;
-  top: 6.4rem;
-  top: calc(3rem + 1.5rem + 1.9rem);
+  top: 9.1rem;
+  top: calc(3.5rem + 3.6rem + 2rem);
   bottom: 0.2rem;
 }
 

--- a/styles/calendar.module.css
+++ b/styles/calendar.module.css
@@ -224,12 +224,12 @@ But then show the next month on small screen, then the next 2 months, then all o
 }
 
 .day_in_month {
-  padding: 0.2rem 0;
+  padding: 0;
 }
 .day_in_month__link {
   display: inline-block;
   color: inherit;
-  padding: 0.1rem;
+  padding: 0.2rem 0.1rem;
   height: 100%;
   width: 100%;
 }

--- a/styles/calendar.module.css
+++ b/styles/calendar.module.css
@@ -224,7 +224,7 @@ But then show the next month on small screen, then the next 2 months, then all o
 }
 
 .day_in_month {
-  padding: 0;
+  padding: 0.2rem 0;
 }
 .day_in_month__link {
   display: inline-block;


### PR DESCRIPTION
Redesign the header to use 2 rows. One for the text "Gruppen" (Groups) and one for the group numbers.