### PR TITLE
Add rewrite to index.html for not found

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
Add a [rewrite](https://vercel.com/docs/projects/project-configuration#rewrites) to `vercel.json`.

It answers with `index.html` for all not found routes (404).

This is for when a user visits a page without having the service worker installed.